### PR TITLE
Fail to apply manifest when EtcdCluster is zero

### DIFF
--- a/api/v1alpha1/etcdcluster_types.go
+++ b/api/v1alpha1/etcdcluster_types.go
@@ -31,6 +31,7 @@ type EtcdClusterSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// Size is the expected size of the etcd cluster.
+	// +kubebuilder:validation:Minimum=1
 	Size int `json:"size"`
 	// Version is the expected version of the etcd container image.
 	Version string `json:"version"`

--- a/config/crd/bases/operator.etcd.io_etcdclusters.yaml
+++ b/config/crd/bases/operator.etcd.io_etcdclusters.yaml
@@ -48,6 +48,7 @@ spec:
                 type: array
               size:
                 description: Size is the expected size of the etcd cluster.
+                minimum: 1
                 type: integer
               storageSpec:
                 description: StorageSpec is the name of the StorageSpec to use for

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: controller
+  newTag: latest

--- a/config/samples/operator_v1alpha1_etcdcluster.yaml
+++ b/config/samples/operator_v1alpha1_etcdcluster.yaml
@@ -6,4 +6,5 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: etcdcluster-sample
 spec:
-  # TODO(user): Add fields here
+  version: v3.5.20
+  size: 0

--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -78,13 +78,6 @@ func (r *EtcdClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
-	if etcdCluster.Spec.Size == 0 {
-		logger.Info("EtcdCluster size is 0..Skipping next steps")
-		return ctrl.Result{}, nil
-	}
-
-	// TODO: Implement finalizer logic here
-
 	logger.Info("Reconciling EtcdCluster", "spec", etcdCluster.Spec)
 
 	// Get the statefulsets which has the same name as the EtcdCluster resource


### PR DESCRIPTION
Adds annotation to prevent users creating EtcdCluster resource with 0 members.
It also removes the validation in the reconcilication loop. CRD updated.

```
k apply -f config/samples/operator_v1alpha1_etcdcluster.yaml
The EtcdCluster "etcdcluster-sample" is invalid: spec.size: Invalid value: 0: spec.size in bod
y should be greater than or equal to 1
```
